### PR TITLE
Fix field error

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_field_device.lua
+++ b/lua/weapons/gmod_tool/stools/wire_field_device.lua
@@ -50,6 +50,7 @@ function TOOL:LeftClick( trace )
 	if string.len( lType ) < 2 then ply:SendHint( "field_type" , 0 ) return false end
 
 	local wire_field_device_obj = Makewire_field_device( ply, trace.HitPos, Ang , self:GetClientInfo("Model") , lType , self:GetClientNumber("ignoreself") , self:GetClientNumber("workonplayers"), self:GetClientNumber("arc") )
+	if not wire_field_device_obj then return end
 
 	local min = wire_field_device_obj:OBBMins()
 	wire_field_device_obj:SetPos( trace.HitPos - trace.HitNormal * min.z )


### PR DESCRIPTION
fixes error where `Makewire_field_device` returns `false` early but the code using it doesn't return early if that function does
